### PR TITLE
Added constants for making filter chain return values easier.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,13 +80,20 @@ endpoint:
 Filter Chains
 ~~~~~~~~~~~~~
 
-Here's an example of using a more customizable retry chain. This example retries
-faile 500 and 503 responses for only idempotent GET and HEAD requests. Retry
-chains are created using the static ``RetrySubscriber::createFilterChain()``
-method. This method accepts an array of callable filters that are each invoked
-one after the other until a filter returns ``true`` (meaning the request should
-be retried), a filter returns ``-1`` (meaning the chain should be broken and
-the request should not be retried), or the last filter has been called.
+You can create more customizable retry logic with filter chains, which are
+created using the static ``RetrySubscriber::createFilterChain()`` method. This
+method accepts an array of callable filters that are each invoked one after the
+other. The filters in the chain should return one of the following values,
+which affects how the rest of the chain is executed.
+
+* ``RetrySubscriber::RETRY`` (i.e., ``true``) – Retry the request.
+* ``RetrySubscriber::DEFER`` (i.e., ``false``) – Defer to the next filter in
+  the chain.
+* ``RetrySubscriber::BREAK_CHAIN`` (i.e., ``-1``) – Stop the filter chain, and
+  do **not** retry the request.
+
+Here's an example using filter chains that retries failed 500 and 503 responses
+for only idempotent GET and HEAD requests.
 
 .. code-block:: php
 
@@ -102,11 +109,11 @@ the request should not be retried), or the last filter has been called.
 
             // Break the filter if it was not an idempotent request
             if (!in_array($method, ['GET', 'HEAD'])) {
-                return -1;
+                return RetrySubscriber::BREAK_CHAIN;
             }
 
             // Otherwise, defer to subsequent filters
-            return false;
+            return RetrySubscriber::DEFER;
         },
         // Performs the last check, returning ``true`` or ``false`` based on
         // if the response received a 500 or 503 status code.

--- a/src/RetrySubscriber.php
+++ b/src/RetrySubscriber.php
@@ -16,6 +16,9 @@ use Psr\Log\LogLevel;
  */
 class RetrySubscriber implements SubscriberInterface
 {
+    const RETRY = true;
+    const DEFER = false;
+    const BREAK_CHAIN = -1;
     const MSG_FORMAT = '[{ts}] {method} {url} - {code} {phrase} - Retries: {retries}, Delay: {delay}, Time: {connect_time}, {total_time}, Error: {error}';
 
     /** @var callable */
@@ -149,7 +152,7 @@ class RetrySubscriber implements SubscriberInterface
     public static function createStatusFilter(array $failureStatuses = null)
     {
         $failureStatuses = $failureStatuses ?: [500, 503];
-        $failureStatuses = array_fill_keys($failureStatuses, 1);
+        $failureStatuses = array_fill_keys($failureStatuses, true);
 
         return function ($retries, AbstractTransferEvent $event) use ($failureStatuses) {
             if (!($response = $event->getResponse())) {

--- a/tests/RetrySubscriberTest.php
+++ b/tests/RetrySubscriberTest.php
@@ -60,13 +60,13 @@ class RetrySubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->createEvent(new Response(500));
         $f = RetrySubscriber::createChainFilter([
-            function () { return false; },
-            function () { return true; },
+            function () { return RetrySubscriber::DEFER; },
+            function () { return RetrySubscriber::RETRY; },
         ]);
         $this->assertTrue($f(1, $e));
-        $f = RetrySubscriber::createChainFilter([function () { return false; }]);
+        $f = RetrySubscriber::createChainFilter([function () { return RetrySubscriber::DEFER; }]);
         $this->assertFalse($f(1, $e));
-        $f = RetrySubscriber::createChainFilter([function () { return true; }]);
+        $f = RetrySubscriber::createChainFilter([function () { return RetrySubscriber::RETRY; }]);
         $this->assertTrue($f(1, $e));
     }
 
@@ -74,9 +74,9 @@ class RetrySubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $e = $this->createEvent(new Response(500));
         $f = RetrySubscriber::createChainFilter([
-            function () { return false; },
-            function () { return -1; },
-            function () { throw new \Exception('Did not break chain!'); },
+            function () { return RetrySubscriber::DEFER; },
+            function () { return RetrySubscriber::BREAK_CHAIN; },
+            function () { $this->fail('Did not break chain!'); },
         ]);
         $this->assertFalse($f(1, $e));
     }


### PR DESCRIPTION
I think adding constants for the filter chain return values (`true`, `false`, `-1`) would make them a lot easier to use and remember.

We can probably come up with better/shorter constant names.
