### PR TITLE
FIXED: Installing section of README gives wrong package name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Add the following to your composer.json:
 
     {
         "require": {
-            "guzzlehttp/streams": "0.1.0"
+            "guzzlehttp/retry-subscriber": "0.1.0"
         }
     }
 


### PR DESCRIPTION
"guzzlehttp/streams" should be "guzzlehttp/retry-subscriber"
