### PR TITLE
Require latest Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": ">=4.0.0"
+        "guzzlehttp/guzzle": "4.*"
     },
     "require-dev": {
         "guzzlehttp/log-subscriber": "0.1.*",


### PR DESCRIPTION
I was getting this error with the current composer.json:

$ php vendor/bin/composer.phar update
Loading composer repositories with package information
Updating dependencies (including require-dev)  
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - guzzlehttp/retry-subscriber 0.1.0 requires guzzlehttp/guzzle 4.0.0-rc.1 -> no matching package found.
    - guzzlehttp/retry-subscriber 0.1.0 requires guzzlehttp/guzzle 4.0.0-rc.1 -> no matching package found.
    - Installation request for guzzlehttp/retry-subscriber 0.1.0 -> satisfiable by guzzlehttp/retry-subscriber[0.1.0].

Potential causes:
- A typo in the package name
- The package is not available in a stable-enough version according to your minimum-stability setting
  see https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion for more details.

Read http://getcomposer.org/doc/articles/troubleshooting.md for further common problems.
