### PR TITLE
Fix sleep default function to apply seccond not milli seconds

### DIFF
--- a/src/RetrySubscriber.php
+++ b/src/RetrySubscriber.php
@@ -220,6 +220,6 @@ class RetrySubscriber implements SubscriberInterface
      */
     private static function defaultSleep($time, AbstractTransferEvent $event)
     {
-        usleep($time * 1000);
+        sleep($time);
     }
 }


### PR DESCRIPTION
In README file you describe **delay** & **sleep** options like: "_amount of time in seconds_" but internal function apply given seconds value like a milli second.

My fix is **BC Break** if users define their options in milliseconds.
In this case I see two options: 
- apply this fix with new tag
- simply change docs :-)
