### PR TITLE
Call "callables" using call_user_func

### DIFF
--- a/src/RetrySubscriber.php
+++ b/src/RetrySubscriber.php
@@ -80,9 +80,9 @@ class RetrySubscriber implements SubscriberInterface
         }
 
         $filterFn = $this->filter;
-        if ($filterFn($retries, $event)) {
+        if (call_user_func($filterFn, $retries, $event)) {
             $delayFn = $this->delayFn;
-            $event->retry($delayFn($retries, $event));
+            $event->retry(call_user_func($delayFn, $retries, $event));
         }
     }
 
@@ -126,7 +126,7 @@ class RetrySubscriber implements SubscriberInterface
             $retries,
             AbstractTransferEvent $event
         ) use ($delayFn, $logger, $formatter) {
-            $delay = $delayFn($retries, $event);
+            $delay = call_user_func($delayFn, $retries, $event);
             $logger->log(LogLevel::NOTICE, $formatter->format(
                 $event->getRequest(),
                 $event->getResponse(),


### PR DESCRIPTION
Valid callables such as `ClassName::staticFunction` can't be invoked as `$callableName()`.

Amazon attempts a valid use case, but fails with `PHP Fatal error:  Call to undefined function GuzzleHttp\Subscriber\Retry\RetrySubscriber::exponentialDelay() in ~/vendor/guzzlehttp/retry-subscriber/src/RetrySubscriber.php on line 85` because of `'delay'  => 'GuzzleHttp\Subscriber\Retry\RetrySubscriber::exponentialDelay'` at https://github.com/aws/aws-sdk-php/blob/802312ff5ebf91785eace3ba77f1c80df153bb4e/src/S3/S3Client.php#L474
