### PR TITLE
Fix retry-subscriber version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Add the following to your composer.json:
 
     {
         "require": {
-            "guzzlehttp/retry-subscriber": "~1.0"
+            "guzzlehttp/retry-subscriber": "~2.0"
         }
     }
 


### PR DESCRIPTION
According to the entire readme, it's based on Guzzle ~5.0, but in the installing section, the subscriber points to version ~1.0 which require guzzle ~4.0
